### PR TITLE
Remove/Clear extra or unwanted emoiji code

### DIFF
--- a/lib/instagram_reporter/instagram_api_caller.rb
+++ b/lib/instagram_reporter/instagram_api_caller.rb
@@ -142,6 +142,11 @@ class InstagramApiCaller < InstagramInteractionsBase
     end
 
     def clear_data(data)
+      # Remove extra `\ud83d` code because each emoji starts with `\ud83d` and
+      # then comes with it's own code, like: \ud83d\ude21 for 😡
+      # but sometimes instagram is sending incorrect code, i.e. sending 2
+      # `\\ud83d` code without original emoiji code.
+      data = data.gsub(/\\ud83d\\ud83d/i, '\\ud83d')
       data = data.gsub(/\\ud83d([^\\])/i, "\\1").gsub(EMOJI_AND_SKIN_TONES_REGEXP, "")
       # Escape special form of multibyte UTF in format \u{}
       data.gsub(/\\u{(\w+)}/, '\u\1')

--- a/spec/cassettes/get_user_info_by_api_token_with_invalid_bio.yml
+++ b/spec/cassettes/get_user_info_by_api_token_with_invalid_bio.yml
@@ -1,0 +1,141 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.instagram.com/v1/users/45364550?client_id=<API_TOKEN>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 09 Apr 2015 11:54:22 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ratelimit-Remaining:
+      - '4383'
+      Content-Language:
+      - en
+      Expires:
+      - Sat, 01 Jan 2000 00:00:00 GMT
+      Vary:
+      - Cookie, Accept-Language, Accept-Encoding
+      X-Ratelimit-Limit:
+      - '5000'
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - private, no-cache, no-store, must-revalidate
+      Set-Cookie:
+      - csrftoken=e90f95afede17a1bda9a4ccde0379d24; expires=Thu, 07-Apr-2016 11:54:22
+        GMT; Max-Age=31449600; Path=/
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '376'
+    body:
+      encoding: UTF-8
+      string: '{"meta":{"code":200},"data":{"username":"yoh_miyhu","bio":"be myself \ud83d\udc8e\ud83d\ud83d\ude0f","website":"","profile_picture":"https://scontent.cdninstagram.com/t51.2885-19/11906329_960233084022564_1448528159_a.jpg","full_name":"\u6c6a\u795dSallyanne","counts":{"media":0,"followed_by":0,"follows":208},"id":"45364550"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.instagram.com/v1/users/45364550?client_id=<API_TOKEN>
+  recorded_at: Thu, 09 Apr 2015 11:54:22 GMT
+- request:
+    method: get
+    uri: https://api.instagram.com/v1/users/45364550?client_id=<API_TOKEN>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Expect:
+      - ''
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Language:
+      - en
+      Expires:
+      - Sat, 01 Jan 2000 00:00:00 GMT
+      Vary:
+      - Cookie, Accept-Language
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - private, no-cache, no-store, must-revalidate
+      Date:
+      - Tue, 23 Aug 2016 14:44:26 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Set-Cookie:
+      - csrftoken=v8Yysimip1pXBwoatbiPflwlT304BOZ6; expires=Tue, 22-Aug-2017 14:44:26
+        GMT; Max-Age=31449600; Path=/; secure
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '124'
+    body:
+      encoding: UTF-8
+      string: '{"meta": {"error_type": "OAuthAccessTokenException", "code": 400, "error_message":
+        "The access_token provided is invalid."}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.instagram.com/v1/users/45364550?client_id=<API_TOKEN>
+  recorded_at: Tue, 23 Aug 2016 14:44:26 GMT
+- request:
+    method: get
+    uri: https://api.instagram.com/v1/users/45364550?client_id=<API_TOKEN>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Expect:
+      - ''
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Language:
+      - en
+      Expires:
+      - Sat, 01 Jan 2000 00:00:00 GMT
+      Vary:
+      - Cookie, Accept-Language
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - private, no-cache, no-store, must-revalidate
+      Date:
+      - Tue, 23 Aug 2016 14:44:29 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Set-Cookie:
+      - csrftoken=wpXqXAQLlUxCO7vfDdQHXheHddvJGSym; expires=Tue, 22-Aug-2017 14:44:29
+        GMT; Max-Age=31449600; Path=/; secure
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '124'
+    body:
+      encoding: UTF-8
+      string: '{"meta": {"error_type": "OAuthAccessTokenException", "code": 400, "error_message":
+        "The access_token provided is invalid."}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.instagram.com/v1/users/45364550?client_id=<API_TOKEN>
+  recorded_at: Tue, 23 Aug 2016 14:44:29 GMT
+recorded_with: VCR 3.0.3

--- a/spec/instagram_api_caller_spec.rb
+++ b/spec/instagram_api_caller_spec.rb
@@ -298,4 +298,12 @@ describe InstagramApiCaller do
       end
     end
   end
+
+  describe 'get_user_info_by_api_token_with_invalid_bio' do
+    it 'returns user data with coorect bio' do
+      VCR.use_cassette('get_user_info_by_api_token_with_invalid_bio') do
+        expect(subject.get_user_info_by_api_token(user_id)['data']['bio']).to eq('bemyself💎😏')
+      end
+    end
+  end
 end


### PR DESCRIPTION
```
 - Remove extra `\ud83d` code because each emoji starts with `\ud83d` and
   then comes with it's own code, like: \ud83d\ude21 for 😡
   but sometimes instagram is sending incorrect code, i.e. sending 2
   `\\ud83d` code without original emoiji code.
```

fixes https://github.com/brandnewio/brandnew.io/issues/4065